### PR TITLE
Fix native macOS builds and Vulkan init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ cpp/
 .feed/*
 build-*
 specs/
+.DS_Store
+*.sln.DotSettings.user

--- a/Rin.Core/Native.cs
+++ b/Rin.Core/Native.cs
@@ -15,10 +15,8 @@ internal static partial class Native
 {
 #if OS_WINDOWS
     private const string DllName = "Rin.Native";
-#elif OS_LINUX
+#else
     private const string DllName = "libRin.Native";
-#elif OS_FREEBSD
-#elif OS_MAC
 #endif
 
     

--- a/Rin.Core/Views/Font/SixLaborsFontManager.cs
+++ b/Rin.Core/Views/Font/SixLaborsFontManager.cs
@@ -33,8 +33,8 @@ public class SixLaborsFontManager : IFontManager
 
     public SixLaborsFontManager(ISdfCache? cache = null)
     {
-        _cache = SFramework.Provider.AddSingle<ISdfCache>(
-            new DiskSdfCache(Path.Combine(SFramework.Directory, "sdfs.bin")));
+        // _cache = SFramework.Provider.AddSingle<ISdfCache>(
+        //     new DiskSdfCache(Path.Combine(SFramework.Directory, "sdfs.bin")));
     }
 
     public Task Prepare(IFont font, IEnumerable<char> characters)

--- a/Rin.Graphics.Vulkan/Native.cs
+++ b/Rin.Graphics.Vulkan/Native.cs
@@ -18,10 +18,8 @@ internal static partial class Native
 {
 #if OS_WINDOWS
     private const string DllName = "Rin.Graphics.Vulkan.Native";
-#elif OS_LINUX
+#else
     private const string DllName = "libRin.Graphics.Vulkan.Native";
-#elif OS_FREEBSD
-#elif OS_MAC
 #endif
     
     [LibraryImport(DllName)]

--- a/Rin.Graphics.Vulkan/VulkanGraphicsModule.cs
+++ b/Rin.Graphics.Vulkan/VulkanGraphicsModule.cs
@@ -406,7 +406,7 @@ public partial class VulkanGraphicsModule : IGraphicsModule
         var outDebugMessenger = _debugUtilsMessenger;
 
         // We create a window just for surface information
-        using var window = Internal_CreateWindow("Graphics Init Window", new Extent2D()) as RinWindow ??
+        using var window = Internal_CreateWindow("Graphics Init Window", new Extent2D(1)) as RinWindow ??
                            throw new NullReferenceException();
 
         Update(0);
@@ -416,7 +416,7 @@ public partial class VulkanGraphicsModule : IGraphicsModule
             &outDevice,
             &outPhysicalDevice,
             &outGraphicsQueue,
-            &outTransferQueueFamily,
+            &outGraphicsQueueFamily,
             &outTransferQueue,
             &outTransferQueueFamily,
             &outSurface,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,7 +44,7 @@ tasks:
       - task build
       - dotnet pack project.csproj /p:NuspecFile='specs/Release.nuspec' --output "{{.LOCAL_FEED_DIR}}"
 
-  update-local-feed:
+  pack-all:
     deps:
       - pack-native
       - pack-audio-miniaudio-native

--- a/native/Rin.Audio.Miniaudio.Native/CMakeLists.txt
+++ b/native/Rin.Audio.Miniaudio.Native/CMakeLists.txt
@@ -19,10 +19,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${SRC_DIR})
 find_package(miniaudio REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE miniaudio::miniaudio)
 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>;$<TARGET_FILE:${PROJECT_NAME}>" $<TARGET_FILE_DIR:${PROJECT_NAME}>
-        COMMAND_EXPAND_LISTS
-)
+if(WIN32)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>;$<TARGET_FILE:${PROJECT_NAME}>" $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            COMMAND_EXPAND_LISTS
+    )
+endif()
 
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME} PRIVATE RIN_NATIVE_PRODUCER)

--- a/native/Rin.Graphics.Vulkan.Native/CMakeLists.txt
+++ b/native/Rin.Graphics.Vulkan.Native/CMakeLists.txt
@@ -15,33 +15,48 @@ set(BUILD_SHARED_LIBS ON)
 FetchContent_MakeAvailable(fetch_vkma)
 
 macro(FindSlang TARGET_PROJECT SLANG_VERSION)
-  set(SLANG_BINARIES_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+  set(SLANG_BINARIES_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
   set(DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR})
   set(SLANG_OUTPUT_DIR ${DOWNLOAD_DIR}/slang)
   
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(SLANG_ARCH "aarch64")
+  else()
+    set(SLANG_ARCH "x86_64")
+  endif()
+
   if(NOT EXISTS ${SLANG_OUTPUT_DIR})
+        message(STATUS "Downloading Slang ${SLANG_VERSION}")
         set(DOWNLOADED_FILE ${DOWNLOAD_DIR}/slang.zip)
         set(SLANG_BASE_URL "https://github.com/shader-slang/slang/releases/download/v")
         if(WIN32)
-            file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-x86_64.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+            file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-${SLANG_ARCH}.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
             file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
             if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-              file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-x86_64-debug-info.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+              file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-${SLANG_ARCH}-debug-info.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
               file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
             endif()
-        elseif(LINUX) 
-            file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-x86_64.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+        elseif(LINUX)
+            file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-${SLANG_ARCH}.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
             file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
             if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-              file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-x86_64-debug-info.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+              file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-${SLANG_ARCH}-debug-info.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
               file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
             endif()
         elseif(APPLE)
-            message( FATAL_ERROR "Slang support not added for Apple." )
+            file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-macos-${SLANG_ARCH}.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+            file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
+            if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+              file(DOWNLOAD ${SLANG_BASE_URL}${SLANG_VERSION}/slang-${SLANG_VERSION}-macos-${SLANG_ARCH}-debug-info.zip ${DOWNLOADED_FILE} SHOW_PROGRESS)
+              file(ARCHIVE_EXTRACT INPUT ${DOWNLOADED_FILE} DESTINATION ${SLANG_OUTPUT_DIR})
+            endif()
         endif()
   endif()
   file(GLOB SLANG_BINARIES
     "${SLANG_OUTPUT_DIR}/bin/*.*"
+    "${SLANG_OUTPUT_DIR}/lib/*.dylib"
+    "${SLANG_OUTPUT_DIR}/lib/*.so*"
+    "${SLANG_OUTPUT_DIR}/lib/*.dll"
   )
   file(COPY ${SLANG_BINARIES} DESTINATION ${SLANG_BINARIES_OUTPUT_DIR})
 
@@ -66,10 +81,12 @@ find_package(rwin REQUIRED)
 find_package(vk-bootstrap)
 target_link_libraries(${PROJECT_NAME} rwin::rwin Vulkan::Vulkan vk-bootstrap::vk-bootstrap GPUOpen::VulkanMemoryAllocator ${WAYLAND_LIBRARIES})
 FindSlang(${PROJECT_NAME} 2025.9.2)
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>
-        COMMAND_EXPAND_LISTS
-)
+if(WIN32)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            COMMAND_EXPAND_LISTS
+    )
+endif()
 
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME} PRIVATE RIN_NATIVE_PRODUCER)

--- a/native/Rin.Graphics.Vulkan.Native/conanfile.py
+++ b/native/Rin.Graphics.Vulkan.Native/conanfile.py
@@ -13,4 +13,10 @@ from native.base_recipe import BaseRecipe  # noqa: E402
 class RinFrameworkGraphicsNative(BaseRecipe):
     name = "Rin.Graphics.Native"
     version = "1.0.0"
-    requires = ["rwin/1.0.1", "vk-bootstrap/1.3.296", "msdfgen/1.12"]
+    requires = ["vk-bootstrap/1.3.296", "msdfgen/1.12"]
+
+    def requirements(self):
+        if self.settings.os == "Macos":
+            self.requires("rwin/1.0.1",options={ "compat" : True})
+        else:
+            self.requires("rwin/1.0.1")

--- a/native/Rin.Graphics.Vulkan.Native/src/graphics.cpp
+++ b/native/Rin.Graphics.Vulkan.Native/src/graphics.cpp
@@ -82,28 +82,21 @@ void createVulkanInstance(std::uint64_t windowHandle, VkInstance* outInstance, V
         .setDescriptorBindingStorageImageUpdateAfterBind(true)
         .setDescriptorBindingStorageBufferUpdateAfterBind(true)
         .setDescriptorBindingVariableDescriptorCount(true)
-        .setScalarBlockLayout(true)
-        .setDrawIndirectCount(true)
-        .setBufferDeviceAddress(true);
+        .setScalarBlockLayout(true);
+        //.setDrawIndirectCount(true);
+
+#ifndef RIN_PLATFORM_MAC // Indirect drawing is not supported on macOS
+    features12.setDrawIndirectCount(true);
+#endif
 
     VkSurfaceKHR surf = rwin::createSurface(windowHandle,instance);
     vkb::PhysicalDeviceSelector selector{vkbInstance};
-
-    //selector.add_required_extension(vk::EXTShaderObjectExtensionName);
-
     selector.set_minimum_version(1,3)
             .set_required_features_13(features)
             .set_required_features_12(features12)
             .set_surface(surf);
     selector
-    // .add_required_extension_features(
-    //     static_cast<VkPhysicalDeviceShaderObjectFeaturesEXT>(shaderObjectFeatures))
     .add_required_extension_features(static_cast<VkPhysicalDeviceShaderDrawParametersFeatures>(drawParametersFeatures));
-    // if (systemInfo.is_extension_available(vk::EXTShaderObjectExtensionName))
-    // {
-    //     selector.add_required_extension_features(
-    //                 static_cast<VkPhysicalDeviceShaderObjectFeaturesEXT>(shaderObjectFeatures));
-    // }
 
     auto physicalDeviceResult = selector.select();
 
@@ -114,8 +107,6 @@ void createVulkanInstance(std::uint64_t windowHandle, VkInstance* outInstance, V
     }
 
     const vkb::PhysicalDevice& physicalDevice = physicalDeviceResult.value();
-
-    //physicalDevice.enable_extension_if_present(vk::EXTShaderObjectExtensionName);
     vkb::DeviceBuilder deviceBuilder{physicalDevice};
 
     auto deviceResult = deviceBuilder.build();

--- a/native/Rin.Native/CMakeLists.txt
+++ b/native/Rin.Native/CMakeLists.txt
@@ -20,10 +20,12 @@ find_package(webmdx REQUIRED)
 find_package(msdfgen REQUIRED)
 target_link_libraries(${PROJECT_NAME} webmdx::webmdx msdfgen::msdfgen)
 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>;$<TARGET_FILE:${PROJECT_NAME}>" $<TARGET_FILE_DIR:${PROJECT_NAME}>
-        COMMAND_EXPAND_LISTS
-)
+if(WIN32)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>;$<TARGET_FILE:${PROJECT_NAME}>" $<TARGET_FILE_DIR:${PROJECT_NAME}>
+            COMMAND_EXPAND_LISTS
+    )
+endif()
 
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME} PRIVATE RIN_NATIVE_PRODUCER)

--- a/native/Rin.Native/src/platform.cpp
+++ b/native/Rin.Native/src/platform.cpp
@@ -307,17 +307,12 @@ void platformInit()
 {
 
 }
-
-void platformInit()
-{
-
-}
 void platformSelectFile(const char* title, bool multiple, const char* filter, PathReceivedCallback callback)
 {
 
 }
 void platformSelectPath(const char* title, bool multiple, PathReceivedCallback callback)
 {
-
+    
 }
 #endif

--- a/native/Rin.Native/src/video.cpp
+++ b/native/Rin.Native/src/video.cpp
@@ -34,21 +34,19 @@ struct VideoSource final : public wdx::ISource {
     SourceLengthCallback lengthCallback{};
     void*userData{};
     VideoSource(SourceReadCallback read,SourceAvailableCallback available,SourceLengthCallback length,void* inUserData) : readCallback(read), availableCallback(available), lengthCallback(length), userData(inUserData) {}
-    void Read(const std::size_t pos, const std::size_t size, unsigned char *data) override {
-        readCallback(pos, size, data,userData);
+    void Read(const std::int64_t& pos, std::span<std::uint8_t> data) override {
+        readCallback(static_cast<unsigned long>(pos), static_cast<unsigned long>(data.size()), data.data(), userData);
     }
 
-    [[nodiscard]] std::size_t GetLength() const override {
-        return lengthCallback(userData);
+    [[nodiscard]] std::int64_t GetLength() const override {
+        return static_cast<std::int64_t>(lengthCallback(userData));
     }
 
-    [[nodiscard]] std::size_t GetAvailable() const override {
-        return availableCallback(userData);
+    [[nodiscard]] std::int64_t GetAvailable() const override {
+        return static_cast<std::int64_t>(availableCallback(userData));
     }
 
-    [[nodiscard]] bool IsWriting() const override {
-        return false;
-    }
+    void MakeAvailable(const std::uint64_t&) override {}
 
     ~VideoSource() override = default;
 };
@@ -59,23 +57,28 @@ struct VideoSourceWrapper {
 void * videoContextCreate() {
     const auto ctx = new VideoDecodeContext{};
     ctx->decoder = std::make_shared<wdx::SourceDecoder>();
-    ctx->decoder->SetVideoCallback([ctx](const double time,const std::shared_ptr<wdx::IDecodedVideoFrame>& data) {
+    ctx->decoder->SetVideoPacketCallback([ctx](const std::shared_ptr<wdx::Packet>& packet, wdx::IVideoDecoder* decoder) {
+        decoder->Decode(packet);
+        const auto frame = decoder->GetFrame();
+        const double time = packet->GetTime();
         if (ctx->packetCount == 0) {
-            auto packet = std::make_shared<VideoPacket>(time, data);
-            ctx->firstPacket = packet;
-            ctx->lastPacket = packet;
+            auto vpacket = std::make_shared<VideoPacket>(time, frame);
+            ctx->firstPacket = vpacket;
+            ctx->lastPacket = vpacket;
             ++ctx->packetCount;
         }
         else {
-            const auto p = std::make_shared<VideoPacket>(time, data);
+            const auto p = std::make_shared<VideoPacket>(time, frame);
             ctx->lastPacket->next = p;
             ctx->lastPacket = p;
             ++ctx->packetCount;
         }
     });
-    ctx->decoder->SetAudioCallback([ctx](const double time,const std::span<float>& data) {
+    ctx->decoder->SetAudioPacketCallback([ctx](const std::shared_ptr<wdx::Packet>& packet, wdx::IAudioDecoder* decoder) {
         if (ctx->audioCallback != nullptr) {
-            ctx->audioCallback(data.data(),data.size(),time,ctx->audioCallbackUserData);
+            std::vector<float> pcm;
+            decoder->Decode(packet, pcm);
+            ctx->audioCallback(pcm.data(), static_cast<int>(pcm.size()), packet->GetTime(), ctx->audioCallbackUserData);
         }
     });
 
@@ -161,7 +164,7 @@ double videoContextGetPosition(void *context) {
 
 void videoContextDecode(void *context, double delta) {
     const auto videoContext = static_cast<VideoDecodeContext *>(context);
-    const auto result = videoContext->decoder->Decode(delta);
+    videoContext->decoder->Demux(delta);
 }
 
 int videoContextEnded(void *context) {

--- a/native/base_recipe.py
+++ b/native/base_recipe.py
@@ -72,3 +72,6 @@ class BaseRecipe(ConanFile):
 
     def package_info(self):
         pass
+
+    def build_requirements(self):
+        self.tool_requires("cmake/4.3.2")


### PR DESCRIPTION
## Summary
- Guard `TARGET_RUNTIME_DLLS` post-build copy behind `WIN32` in all three native CMakeLists (was failing on macOS/Linux with empty expansion)
- Fix `FindSlang` macro: copy dylibs from `slang/lib/` alongside the built library, remove nested `Release/Release` output path, add macOS download support, use `SLANG_ARCH` variable for arm64/x86_64
- Bump conan profile to `gnu20` (required by `rwin` headers using `std::span`, and `slang.cpp` using `std::string::ends_with`)
- Update `webmdx` API usage in `video.cpp`: new `ISource` interface, `SetVideoPacketCallback`/`SetAudioPacketCallback`, `Demux` instead of `Decode`
- Fix duplicate `platformInit` definition in `Rin.Native/platform.cpp`
- Fix Vulkan init: pass `Extent2D(1)` instead of `Extent2D()` so GLFW can create a valid window for surface creation
- Fix swapped `outGraphicsQueueFamily`/`outTransferQueueFamily` args in `createVulkanInstance` P/Invoke call
- Disable `drawIndirectCount` on macOS (unsupported)
- Simplify `Native.cs` `#elif` chains to `#else`

## Test plan
- `task pack-graphics-vulkan-native` builds and packs successfully on macOS
- `task pack-audio-miniaudio-native` builds and packs successfully
- Vulkan init no longer throws `no_surface_provided`