### PR TITLE
Add GraphicsShader/ComputeShader source generator, thread module deps through constructors

### DIFF
--- a/Rin.Core/Animation/AnimationRunner.cs
+++ b/Rin.Core/Animation/AnimationRunner.cs
@@ -1,9 +1,9 @@
 ﻿namespace Rin.Core.Animation;
 
-public class AnimationRunner
+public class AnimationRunner(IApplication? application = null)
 {
     private readonly HashSet<AnimationState> _animations = [];
-    private readonly IApplication _application = IApplication.Get();
+    private readonly IApplication _application = application ?? IApplication.Get();
     private float _currentEndTime;
 
     public void Update()

--- a/Rin.Core/Application.cs
+++ b/Rin.Core/Application.cs
@@ -160,14 +160,9 @@ public abstract class Application : IApplication
     {
         InitializePlatform();
 
-        _audioModule = CreateAudioModule();
-        _graphicsModule = CreateGraphicsModule();
-        _viewsModule = CreateViewsModule();
-
-        Global.Provider.AddSingle(_audioModule);
-        Global.Provider.AddSingle(_graphicsModule);
-        Global.Provider.AddSingle(_viewsModule);
-
+        _audioModule = Global.Provider.AddSingle(CreateAudioModule());
+        _graphicsModule = Global.Provider.AddSingle(CreateGraphicsModule());
+        _viewsModule = Global.Provider.AddSingle(CreateViewsModule());
         _modules = [_audioModule, _graphicsModule, _viewsModule];
 
 

--- a/Rin.Core/Graphics/HostImage.cs
+++ b/Rin.Core/Graphics/HostImage.cs
@@ -28,9 +28,11 @@ public class HostImage : IHostImage
     }
 
     public Task CreateTexture(out ResourceHandle handle, ImageFilter filter = ImageFilter.Linear,
-        ImageTiling tiling = ImageTiling.Repeat, bool mips = false, string? debugName = null)
+        ImageTiling tiling = ImageTiling.Repeat, bool mips = false, string? debugName = null,
+        IGraphicsModule? graphicsModule = null)
     {
-        return IGraphicsModule.Get().CreateTexture(out handle, ToBuffer(), Extent, Format.ToDeviceFormat(), mips);
+        return (graphicsModule ?? IGraphicsModule.Get()).CreateTexture(out handle, ToBuffer(), Extent,
+            Format.ToDeviceFormat(), mips);
     }
 
     public Extent2D Extent => new()

--- a/Rin.Core/Graphics/IHostImage.cs
+++ b/Rin.Core/Graphics/IHostImage.cs
@@ -11,7 +11,7 @@ public interface IHostImage : IDisposable
 
     public Task CreateTexture(out ResourceHandle handle, ImageFilter filter = ImageFilter.Linear,
         ImageTiling tiling = ImageTiling.Repeat,
-        bool mips = false, string? debugName = null);
+        bool mips = false, string? debugName = null, IGraphicsModule? graphicsModule = null);
 
     /// <summary>
     ///     Saves the image as png

--- a/Rin.Core/Graphics/Shaders/ComputeShaderAttribute.cs
+++ b/Rin.Core/Graphics/Shaders/ComputeShaderAttribute.cs
@@ -1,0 +1,14 @@
+namespace Rin.Core.Graphics.Shaders;
+
+/// <summary>
+/// Marks a <c>partial</c> <see cref="IComputeShader"/> property as generator-backed. The generator emits
+/// <c>=&gt; field ??= IGraphicsModule.Get().MakeCompute(path)</c> for the property.
+/// </summary>
+/// <example>
+/// <code>
+/// // ReSharper disable once MemberCanBeMadeStatic.Global
+/// [ComputeShader("cs/assets/test/blur.slang")]
+/// public partial IComputeShader BlurShader { get; }
+/// </code>
+/// </example>
+public sealed class ComputeShaderAttribute(string path) : ShaderAttribute(path);

--- a/Rin.Core/Graphics/Shaders/GraphicsShaderAttribute.cs
+++ b/Rin.Core/Graphics/Shaders/GraphicsShaderAttribute.cs
@@ -1,0 +1,14 @@
+namespace Rin.Core.Graphics.Shaders;
+
+/// <summary>
+/// Marks a <c>partial</c> <see cref="IGraphicsShader"/> property as generator-backed. The generator emits
+/// <c>=&gt; field ??= IGraphicsModule.Get().MakeGraphics(path)</c> for the property.
+/// </summary>
+/// <example>
+/// <code>
+/// // ReSharper disable once MemberCanBeMadeStatic.Global
+/// [GraphicsShader("fs/assets/test/pretty.slang")]
+/// public partial IGraphicsShader PrettyShader { get; }
+/// </code>
+/// </example>
+public sealed class GraphicsShaderAttribute(string path) : ShaderAttribute(path);

--- a/Rin.Core/Graphics/Shaders/LoadShaderAttribute.cs
+++ b/Rin.Core/Graphics/Shaders/LoadShaderAttribute.cs
@@ -1,6 +1,0 @@
-﻿namespace Rin.Core.Graphics.Shaders;
-
-// [AttributeUsage(AttributeTargets.Property)]
-// public class LoadShaderAttribute(string path) : Attribute
-// {
-// }

--- a/Rin.Core/Graphics/Shaders/ShaderAttribute.cs
+++ b/Rin.Core/Graphics/Shaders/ShaderAttribute.cs
@@ -1,0 +1,22 @@
+namespace Rin.Core.Graphics.Shaders;
+
+/// <summary>
+/// Common base for <see cref="GraphicsShaderAttribute"/> and <see cref="ComputeShaderAttribute"/>. Marks a
+/// <c>partial</c> property as generator-backed: the source generator emits the other half of the partial
+/// property, returning the shader loaded from <see cref="Path"/> via
+/// <see cref="global::Rin.Core.Graphics.IGraphicsModule.Get"/>.
+/// </summary>
+/// <remarks>
+/// The property must be an instance member (the generator rejects <c>static</c> properties). Rider/ReSharper
+/// only inspects the hand-written defining declaration - it excludes the generator's own output from analysis
+/// because that file is marked <c>&lt;auto-generated/&gt;</c> - so it can't see the <c>field ??= ...</c> body
+/// that actually uses instance state, and may incorrectly suggest "member can be made static". Suppress that
+/// with <c>// ReSharper disable once MemberCanBeMadeStatic.Global</c> (or <c>.Local</c> for a non-public
+/// property) above the declaration, as shown in the examples on <see cref="GraphicsShaderAttribute"/> and
+/// <see cref="ComputeShaderAttribute"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property)]
+public abstract class ShaderAttribute(string path) : Attribute
+{
+    public string Path { get; } = path;
+}

--- a/Rin.Core/Shared/Video/WebmVideoPlayer.cs
+++ b/Rin.Core/Shared/Video/WebmVideoPlayer.cs
@@ -15,6 +15,7 @@ public class WebmVideoPlayer : IVideoPlayer
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private readonly IntPtr _context;
 
+    private readonly IAudioModule _audioModule;
     private readonly Func<int, int, IPushStream>? _createStream;
     private readonly AutoResetEvent _decodeEvent = new(false);
     private readonly ManualResetEvent _decodeFinishedEvent = new(true);
@@ -44,8 +45,9 @@ public class WebmVideoPlayer : IVideoPlayer
         }
     }
 
-    public WebmVideoPlayer()
+    public WebmVideoPlayer(IAudioModule? audioModule = null)
     {
+        _audioModule = audioModule ?? IAudioModule.Get();
         _context = Native.videoContextCreate();
         unsafe
         {
@@ -82,7 +84,7 @@ public class WebmVideoPlayer : IVideoPlayer
         });
     }
 
-    public WebmVideoPlayer(Func<int, int, IPushStream> createAudioStream) : this()
+    public WebmVideoPlayer(Func<int, int, IPushStream> createAudioStream, IAudioModule? audioModule = null) : this(audioModule)
     {
         _createStream = createAudioStream;
     }
@@ -177,7 +179,7 @@ public class WebmVideoPlayer : IVideoPlayer
         {
             _audioPacketsStartAt = time;
             _audioStream = _createStream?.Invoke(AudioSampleRate, AudioChannels) ??
-                           IAudioModule.Get().MasterAudioGroup.CreatePushStream(AudioSampleRate, AudioChannels);
+                           _audioModule.MasterAudioGroup.CreatePushStream(AudioSampleRate, AudioChannels);
             if (IsPlaying) _audioStream.Play();
         }
 

--- a/Rin.Core/Views/Content/TextBoxView.cs
+++ b/Rin.Core/Views/Content/TextBoxView.cs
@@ -19,13 +19,14 @@ public class TextBoxView : ContentView
 
     private string _content = string.Empty;
     private string _fontFamily = "Noto Sans";
-    private IFontManager _fontManager = IViewsModule.Get().FontManager;
+    private IFontManager _fontManager;
     private float _fontSize = 100.0f;
     private bool _wrapContent;
     protected float? Wrap;
 
-    public TextBoxView()
+    public TextBoxView(IViewsModule? viewsModule = null)
     {
+        _fontManager = (viewsModule ?? IViewsModule.Get()).FontManager;
         _cachedLayouts = null;
         _cachedBounds = null;
         MakeNewFont();

--- a/Rin.Core/Views/Content/TextInputBoxView.cs
+++ b/Rin.Core/Views/Content/TextInputBoxView.cs
@@ -12,13 +12,16 @@ namespace Rin.Core.Views.Content;
 
 public class TextInputBoxView : TextBoxView
 {
+    private readonly IApplication _application;
+
     private readonly Timer _typingTimer = new(200)
     {
         AutoReset = false
     };
 
-    public TextInputBoxView()
+    public TextInputBoxView(IApplication? application = null)
     {
+        _application = application ?? IApplication.Get();
         CursorPosition = Content.Length - 1;
         _typingTimer.Elapsed += (_, _) => IsTyping = false;
     }
@@ -134,7 +137,7 @@ public class TextInputBoxView : TextBoxView
 
         var height = LineHeight;
         var color = ForegroundColor;
-        var sin = (float.Sin(IApplication.Get().TimeSeconds * 5) + 1.0f) / 2.0f;
+        var sin = (float.Sin(_application.TimeSeconds * 5) + 1.0f) / 2.0f;
         color.A *= IsTyping ? 1.0f : sin > 0.35 ? 1.0f : 0.0f;
         commands.AddRect(transform.Translate(offset), new Vector2(2.0f, height), color);
     }

--- a/Rin.Core/Views/Content/VideoPlayerView.cs
+++ b/Rin.Core/Views/Content/VideoPlayerView.cs
@@ -60,10 +60,13 @@ internal class CreateVideoResourcesPass(VideoCommand[] commands) : IPass
     }
 }
 
-internal class VideoCommandHandler : ICommandHandlerWithPreAdd
+internal partial class VideoCommandHandler : ICommandHandlerWithPreAdd
 {
-    private readonly IGraphicsShader _shader = IGraphicsModule.Get()
-        .MakeGraphics("Core/Shaders/Views/video.slang");
+    [GraphicsShader("Core/Shaders/Views/video.slang")]
+    private partial IGraphicsShader VideoShader
+    {
+        get;
+    }
 
     private VideoCommand[] _commands = [];
     private uint _itemBufferId;
@@ -91,7 +94,7 @@ internal class VideoCommandHandler : ICommandHandlerWithPreAdd
     public void Execute(IPassConfig passConfig,
         SurfaceContext surfaceContext, ICompiledGraph graph, IExecutionContext ctx)
     {
-        if (_shader.Bind(ctx) is { } bindContext)
+        if (VideoShader.Bind(ctx) is { } bindContext)
         {
             var frameImages = _resourcesPass.VideoImageFrameIds.Select(graph.GetImage).ToArray();
             var buffer = graph.GetBufferOrException(_itemBufferId);

--- a/Rin.Core/Views/Font/SixLaborsFontManager.cs
+++ b/Rin.Core/Views/Font/SixLaborsFontManager.cs
@@ -22,6 +22,7 @@ public class SixLaborsFontManager : IFontManager
     private readonly ISdfCache? _cache;
     private readonly CancellationTokenSource _cancellationSource = new();
     private readonly FontCollection _collection = new();
+    private readonly IGraphicsModule _graphicsModule;
 
     private readonly LiveGlyphInfo _defaultLiveGlyph = new()
     {
@@ -33,8 +34,9 @@ public class SixLaborsFontManager : IFontManager
 
     private readonly ConcurrentDictionary<FontFamily, IFont> _fonts = [];
 
-    public SixLaborsFontManager(ISdfCache? cache = null)
+    public SixLaborsFontManager(ISdfCache? cache = null, IGraphicsModule? graphicsModule = null)
     {
+        _graphicsModule = graphicsModule ?? IGraphicsModule.Get();
         // _cache = Global.Provider.AddSingle<ISdfCache>(
         //     new DiskSdfCache(Path.Combine(Global.Directory, "sdfs.bin")));
     }
@@ -88,7 +90,7 @@ public class SixLaborsFontManager : IFontManager
                                 size.Y / result.Image.Extent.Height)
                         };
 
-                        result.Image.CreateTexture(out glyph.AtlasHandle).Then(() =>
+                        result.Image.CreateTexture(out glyph.AtlasHandle, graphicsModule: _graphicsModule).Then(() =>
                         {
                             var id = toGenerate[index].Second;
                             if (!_atlases.TryGetValue(id, out var val)) return;
@@ -222,7 +224,7 @@ public class SixLaborsFontManager : IFontManager
                             }
                         });
                         // , tiling: ImageTiling.ClampEdge
-                        packedAtlas.CreateTexture(out var handle).Then(() =>
+                        packedAtlas.CreateTexture(out var handle, graphicsModule: _graphicsModule).Then(() =>
                         {
                             foreach (var key in glyphsInAtlas.Where(_atlases.ContainsKey))
                             {
@@ -290,7 +292,7 @@ public class SixLaborsFontManager : IFontManager
     {
         _cancellationSource.Cancel();
         _backgroundTaskQueue.Dispose();
-        IGraphicsModule.Get()
+        _graphicsModule
             .FreeResourceHandles(_atlases.Select(c => c.Value.AtlasHandle).Where(c => c.Id >= 0).ToArray());
         _atlases.Clear();
     }

--- a/Rin.Core/Views/Graphics/Blur/BlurCommandHandler.cs
+++ b/Rin.Core/Views/Graphics/Blur/BlurCommandHandler.cs
@@ -89,10 +89,12 @@ internal struct Push
     public required int IsHorizontal;
 }
 
-internal class BlurFirstPassCommandHandler : ICommandHandler
+internal partial class BlurFirstPassCommandHandler : ICommandHandler
 {
-    private readonly IGraphicsShader _shader = IGraphicsModule.Get()
-        .MakeGraphics("Core/Shaders/Views/blur.slang");
+    [GraphicsShader("Core/Shaders/Views/blur.slang")]
+    private partial IGraphicsShader _shader {
+        get;
+    }
 
     private uint[] _bufferIds = [];
     private BlurFirstPassCommand[] _commands = [];
@@ -157,10 +159,12 @@ internal class BlurFirstPassCommandHandler : ICommandHandler
     }
 }
 
-internal class BlurSecondPassCommandHandler : ICommandHandler
+internal partial class BlurSecondPassCommandHandler : ICommandHandler
 {
-    private readonly IGraphicsShader _shader = IGraphicsModule.Get()
-        .MakeGraphics("Core/Shaders/Views/blur.slang");
+    [GraphicsShader("Core/Shaders/Views/blur.slang")]
+    private partial IGraphicsShader _shader {
+        get;
+    }
 
     private uint[] _bufferIds = [];
     private BlurSecondPassCommand[] _commands = [];

--- a/Rin.Core/Views/Graphics/Passes/StencilWritePass.cs
+++ b/Rin.Core/Views/Graphics/Passes/StencilWritePass.cs
@@ -6,14 +6,15 @@ using Rin.Core.Graphics.Shaders;
 
 namespace Rin.Core.Views.Graphics.Passes;
 
-public class StencilWritePass : IPass
+public partial class StencilWritePass : IPass
 {
     private readonly StencilClip[] _clips;
     private readonly uint _mask;
-
-    private readonly IGraphicsShader _stencilShader = IGraphicsModule.Get()
-        .MakeGraphics("Core/Shaders/Views/stencil_batch.slang");
-
+    
+    [GraphicsShader("Core/Shaders/Views/stencil_batch.slang")]
+    private partial IGraphicsShader StencilShader {
+        get;
+    }
     private readonly SurfaceContext _surfaceContext;
 
     private uint _clipsBufferId;
@@ -38,7 +39,7 @@ public class StencilWritePass : IPass
 
     public void Execute(ICompiledGraph graph, IExecutionContext ctx)
     {
-        if (_stencilShader.Bind(ctx) is { } bindContext)
+        if (StencilShader.Bind(ctx) is { } bindContext)
         {
             var stencilImage = graph.GetImageOrException(StencilImageId);
             var clipsBuffer = graph.GetBufferOrException(_clipsBufferId);

--- a/Rin.Core/Views/Graphics/Quads/DefaultQuadBatcher.cs
+++ b/Rin.Core/Views/Graphics/Quads/DefaultQuadBatcher.cs
@@ -7,14 +7,14 @@ using Rin.Core.Graphics.Shaders;
 namespace Rin.Core.Views.Graphics.Quads;
 
 [ViewsBatcher]
-public sealed class DefaultQuadBatcher : SimpleQuadBatcher<QuadBatch>
+public sealed partial class DefaultQuadBatcher : SimpleQuadBatcher<QuadBatch>
 {
-    private readonly IGraphicsShader _batchShader = IGraphicsModule.Get()
-        .MakeGraphics("Core/Shaders/Views/batch.slang");
+    [GraphicsShader("Core/Shaders/Views/batch.slang")]
+    private partial IGraphicsShader BatchShader { get; }
 
     protected override IGraphicsShader GetShader()
     {
-        return _batchShader;
+        return BatchShader;
     }
 
     protected override QuadBatch MakeNewBatch()

--- a/Rin.Core/Views/Graphics/Surface.cs
+++ b/Rin.Core/Views/Graphics/Surface.cs
@@ -25,9 +25,9 @@ public abstract class Surface : ISurface
     private bool _isCursorIn;
     private CursorDownSurfaceEvent? _lastCursorDownEvent;
 
-    protected Surface()
+    protected Surface(IGraphicsModule? graphicsModule = null)
     {
-        _sGraphicsModule = IGraphicsModule.Get();
+        _sGraphicsModule = graphicsModule ?? IGraphicsModule.Get();
         _rootView.NotifyAddedToSurface(this);
         _rootView.InvalidateLayout();
     }

--- a/Rin.SourceGenerators/Rin.Core.Generators/AudioEffectGenerator.cs
+++ b/Rin.SourceGenerators/Rin.Core.Generators/AudioEffectGenerator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -84,44 +83,13 @@ public class AudioEffectGenerator : IIncrementalGenerator
         }
     }
 
-    static bool IsPartial(INamedTypeSymbol type)
-    {
-        foreach (var syntaxRef in type.DeclaringSyntaxReferences)
-        {
-            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl)
-            {
-                if (typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
-                    return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Builds a filesystem-safe, collision-resistant hint name for a generated source file
-    /// from a type's fully-qualified name (handles generics, nested types, and namespace clashes).
-    /// </summary>
-    private static string GetSafeHintName(INamedTypeSymbol typeSymbol)
-    {
-        var fullyQualified = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-
-        var sb = new StringBuilder(fullyQualified.Length);
-        foreach (var c in fullyQualified)
-        {
-            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
-        }
-
-        return sb.ToString();
-    }
-
     /// <summary>
     /// Generates the boilerplate for a specific audio effect.
     /// </summary>
     private static void GenerateEffect(SourceProductionContext context, INamedTypeSymbol typeSymbol,
         Compilation compilation)
     {
-        if (!IsPartial(typeSymbol))
+        if (!GeneratorUtils.IsPartial(typeSymbol))
         {
             context.ReportDiagnostic(Diagnostic.Create(
                     Diagnostics.Audio.EffectMustBePartial,
@@ -490,6 +458,6 @@ public class AudioEffectGenerator : IIncrementalGenerator
         output
             .CloseBrace();
 
-        context.AddSource($"AudioEffect_{GetSafeHintName(typeSymbol)}.g.cs", output.ToSourceText());
+        context.AddSource($"AudioEffect_{GeneratorUtils.GetSafeHintName(typeSymbol)}.g.cs", output.ToSourceText());
     }
 }

--- a/Rin.SourceGenerators/Rin.Core.Generators/Diagnostics.cs
+++ b/Rin.SourceGenerators/Rin.Core.Generators/Diagnostics.cs
@@ -95,4 +95,55 @@ internal static class Diagnostics
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
     }
+
+    internal static class Shader
+    {
+        public static readonly DiagnosticDescriptor AmbiguousShaderAttribute = new(
+            id: "RIN00012",
+            title: "Ambiguous shader attribute",
+            messageFormat: "Property '{0}' declares multiple ShaderAttribute-derived attributes; only one is allowed",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor ContainingTypeMustBePartial = new(
+            id: "RIN00013",
+            title: "Containing type must be partial",
+            messageFormat: "Type '{0}' containing shader property '{1}' must be declared partial so generated code can extend it",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor PropertyMustBePartial = new(
+            id: "RIN00014",
+            title: "Shader property must be partial",
+            messageFormat: "Property '{0}' must be declared partial so the generator can provide its implementation",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor PropertyMustBeGetOnly = new(
+            id: "RIN00015",
+            title: "Shader property must be get-only",
+            messageFormat: "Property '{0}' must declare a getter only (no setter/init) - the generator produces a computed value",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor InvalidPropertyType = new(
+            id: "RIN00016",
+            title: "Invalid shader property type",
+            messageFormat: "Property '{0}' annotated with [{1}] must be of type {2}",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor PropertyMustNotBeStatic = new(
+            id: "RIN00017",
+            title: "Shader property must not be static",
+            messageFormat: "Property '{0}' must be an instance property - static shader properties are not supported",
+            category: "Rin.Graphics",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+    }
 }

--- a/Rin.SourceGenerators/Rin.Core.Generators/GeneratorUtils.cs
+++ b/Rin.SourceGenerators/Rin.Core.Generators/GeneratorUtils.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rin.Core.Generators;
+
+internal static class GeneratorUtils
+{
+    /// <summary>
+    /// Checks whether any partial declaration of <paramref name="type"/> carries the <c>partial</c> modifier.
+    /// </summary>
+    public static bool IsPartial(INamedTypeSymbol type)
+    {
+        foreach (var syntaxRef in type.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl)
+            {
+                if (typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Builds a filesystem-safe, collision-resistant hint name for a generated source file
+    /// from a type's fully-qualified name (handles generics, nested types, and namespace clashes).
+    /// </summary>
+    public static string GetSafeHintName(INamedTypeSymbol typeSymbol)
+    {
+        var fullyQualified = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        var sb = new StringBuilder(fullyQualified.Length);
+        foreach (var c in fullyQualified)
+        {
+            sb.Append(char.IsLetterOrDigit(c) || c == '_' ? c : '_');
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Rin.SourceGenerators/Rin.Core.Generators/GraphicsShaderGenerator.cs
+++ b/Rin.SourceGenerators/Rin.Core.Generators/GraphicsShaderGenerator.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rin.Core.Generators;
+
+[Generator]
+public class GraphicsShaderGenerator : IIncrementalGenerator
+{
+    private const string ShaderAttributeFullName = "Rin.Core.Graphics.Shaders.ShaderAttribute";
+    private const string GraphicsShaderAttributeFullName = "Rin.Core.Graphics.Shaders.GraphicsShaderAttribute";
+    private const string ComputeShaderAttributeFullName = "Rin.Core.Graphics.Shaders.ComputeShaderAttribute";
+    private const string GraphicsShaderInterfaceFullName = "Rin.Core.Graphics.Shaders.IGraphicsShader";
+    private const string ComputeShaderInterfaceFullName = "Rin.Core.Graphics.Shaders.IComputeShader";
+    private const string GraphicsModuleFullName = "Rin.Core.Graphics.IGraphicsModule";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Filter for properties that might carry a [GraphicsShader]/[ComputeShader] attribute.
+        var properties = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (s, _) => s is PropertyDeclarationSyntax { AttributeLists.Count: > 0 },
+                transform: static (ctx, _) => GetPropertyForSourceGen(ctx))
+            .Where(static p => p.propertyDeclaration is not null);
+
+        context.RegisterSourceOutput(context.CompilationProvider.Combine(properties.Collect()),
+            static (spc, source) => Execute(spc, source.Left, source.Right));
+    }
+
+    private static bool InheritsFromOrEquals(INamedTypeSymbol? type, string fullName)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.ToDisplayString() == fullName) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a property declaration carries one or more attributes deriving from
+    /// <c>ShaderAttribute</c>, using semantic analysis to avoid string matching pitfalls.
+    /// </summary>
+    private static (PropertyDeclarationSyntax? propertyDeclaration, ImmutableArray<INamedTypeSymbol> attributeClasses)
+        GetPropertyForSourceGen(GeneratorSyntaxContext context)
+    {
+        var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+        var matches = ImmutableArray.CreateBuilder<INamedTypeSymbol>();
+
+        foreach (var attributeList in propertyDeclaration.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                if (ModelExtensions.GetSymbolInfo(context.SemanticModel, attribute).Symbol is IMethodSymbol
+                    {
+                        ContainingType: var attrType
+                    } &&
+                    InheritsFromOrEquals(attrType, ShaderAttributeFullName))
+                {
+                    matches.Add(attrType);
+                }
+            }
+        }
+
+        return matches.Count > 0
+            ? (propertyDeclaration, matches.ToImmutable())
+            : (null, ImmutableArray<INamedTypeSymbol>.Empty);
+    }
+
+    private static void Execute(SourceProductionContext context, Compilation compilation,
+        ImmutableArray<(PropertyDeclarationSyntax? propertyDeclaration, ImmutableArray<INamedTypeSymbol> attributeClasses
+            )> properties)
+    {
+        if (properties.IsDefaultOrEmpty) return;
+
+        var graphicsShaderType = compilation.GetTypeByMetadataName(GraphicsShaderInterfaceFullName);
+        var computeShaderType = compilation.GetTypeByMetadataName(ComputeShaderInterfaceFullName);
+        var graphicsModuleType = compilation.GetTypeByMetadataName(GraphicsModuleFullName);
+        if (graphicsShaderType == null || computeShaderType == null || graphicsModuleType == null) return;
+
+        var byType =
+            new Dictionary<INamedTypeSymbol, List<(IPropertySymbol property, INamedTypeSymbol attributeClass)>>(
+                SymbolEqualityComparer.Default);
+
+        foreach (var item in properties)
+        {
+            if (item.propertyDeclaration is not { } propertyDeclaration) continue;
+
+            if (item.attributeClasses.Length > 1)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.AmbiguousShaderAttribute,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    propertyDeclaration.Identifier.Text));
+                continue;
+            }
+
+            var semanticModel = compilation.GetSemanticModel(propertyDeclaration.SyntaxTree);
+            if (ModelExtensions.GetDeclaredSymbol(semanticModel, propertyDeclaration) is not IPropertySymbol
+                propertySymbol)
+                continue;
+
+            var attributeClass = item.attributeClasses[0];
+            var containingType = propertySymbol.ContainingType;
+
+            if (propertySymbol.IsStatic)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.PropertyMustNotBeStatic,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    propertySymbol.Name));
+                continue;
+            }
+
+            if (!GeneratorUtils.IsPartial(containingType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.ContainingTypeMustBePartial,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    containingType.ToDisplayString(), propertySymbol.Name));
+                continue;
+            }
+
+            // A valid partial-property *defining* declaration is bodyless: `partial T Foo { get; }`.
+            if (!propertyDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword) ||
+                propertyDeclaration.ExpressionBody is not null ||
+                (propertyDeclaration.AccessorList?.Accessors
+                    .Any(a => a.Body is not null || a.ExpressionBody is not null) ?? true))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.PropertyMustBePartial,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    propertySymbol.Name));
+                continue;
+            }
+
+            var accessors = propertyDeclaration.AccessorList!.Accessors;
+            if (accessors.Count != 1 || accessors[0].Kind() != SyntaxKind.GetAccessorDeclaration)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.PropertyMustBeGetOnly,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    propertySymbol.Name));
+                continue;
+            }
+
+            var isGraphics = attributeClass.ToDisplayString() == GraphicsShaderAttributeFullName;
+            var isCompute = attributeClass.ToDisplayString() == ComputeShaderAttributeFullName;
+            var expectedType = isGraphics ? graphicsShaderType : isCompute ? computeShaderType : null;
+            if (expectedType == null) continue; // A ShaderAttribute-derived type we don't know how to emit for.
+
+            if (!SymbolEqualityComparer.Default.Equals(propertySymbol.Type, expectedType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.Shader.InvalidPropertyType,
+                    propertyDeclaration.Identifier.GetLocation(),
+                    propertySymbol.Name, attributeClass.Name, expectedType.ToDisplayString()));
+                continue;
+            }
+
+            if (!byType.TryGetValue(containingType, out var list))
+            {
+                list = [];
+                byType[containingType] = list;
+            }
+
+            list.Add((propertySymbol, attributeClass));
+        }
+
+        foreach (var (containingType, propertyList) in byType)
+        {
+            GenerateShaderProperties(context, containingType, propertyList, graphicsModuleType);
+        }
+    }
+
+    /// <summary>
+    /// Emits the implementing partial declaration for every generator-backed shader property on a type.
+    /// </summary>
+    private static void GenerateShaderProperties(SourceProductionContext context, INamedTypeSymbol containingType,
+        List<(IPropertySymbol property, INamedTypeSymbol attributeClass)> properties,
+        INamedTypeSymbol graphicsModuleType)
+    {
+        var namespaceName = containingType.ContainingNamespace.ToDisplayString();
+        var typeName = containingType.Name;
+        var kind = containingType.IsValueType ? "struct" : "class";
+        var graphicsModuleDisplay = graphicsModuleType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        var output = new SourceBuilder();
+        output
+            .Line("// <auto-generated/>")
+            .Line()
+            .Line($"namespace {namespaceName};")
+            .Line($"partial {kind} {typeName}")
+            .OpenBrace();
+
+        foreach (var (property, attributeClass) in properties)
+        {
+            var attributeData = property.GetAttributes()
+                .First(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeClass));
+            var path = (string)attributeData.ConstructorArguments[0].Value!;
+            var factoryMethod = attributeClass.ToDisplayString() == GraphicsShaderAttributeFullName
+                ? "MakeGraphics"
+                : "MakeCompute";
+            var propertyType = property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var pathLiteral = SymbolDisplay.FormatLiteral(path, quote: true);
+            var accessibility = GetAccessibilityModifier(property.DeclaredAccessibility);
+
+            output.Line(
+                $"{accessibility} partial {propertyType} {property.Name} => field ??= {graphicsModuleDisplay}.Get().{factoryMethod}({pathLiteral});");
+        }
+
+        output.CloseBrace();
+
+        context.AddSource($"Shader_{GeneratorUtils.GetSafeHintName(containingType)}.g.cs", output.ToSourceText());
+    }
+
+    private static string GetAccessibilityModifier(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Public => "public",
+        Accessibility.Private => "private",
+        Accessibility.Protected => "protected",
+        Accessibility.Internal => "internal",
+        Accessibility.ProtectedOrInternal => "protected internal",
+        Accessibility.ProtectedAndInternal => "private protected",
+        _ => "private"
+    };
+}

--- a/Rin.SourceGenerators/Rin.SourceGenerators.Tests/GraphicsShaderGeneratorTests.cs
+++ b/Rin.SourceGenerators/Rin.SourceGenerators.Tests/GraphicsShaderGeneratorTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Rin.Core.Generators;
+using Rin.Core.Graphics;
+using Xunit;
+
+namespace Rin.SourceGenerators.Tests;
+
+public class GraphicsShaderGeneratorTests
+{
+    // The full set of reference assemblies (not just System.Private.CoreLib) is needed so custom
+    // attribute base-type resolution (ShaderAttribute -> Attribute) doesn't fail with CS0012.
+    private static readonly MetadataReference[] References = ((string)AppContext
+            .GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+        .Split(Path.PathSeparator)
+        .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+        .Append(MetadataReference.CreateFromFile(typeof(IGraphicsModule).Assembly.Location))
+        .ToArray();
+
+    private static GeneratorDriverRunResult Run(string source)
+    {
+        var generator = new GraphicsShaderGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator);
+        var compilation = CSharpCompilation.Create(nameof(GraphicsShaderGeneratorTests),
+            [CSharpSyntaxTree.ParseText(source)], References);
+        return driver.RunGenerators(compilation).GetRunResult();
+    }
+
+    [Fact]
+    public void GeneratesShaderProperties()
+    {
+        const string source = @"
+using Rin.Core.Graphics;
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public partial IGraphicsShader PrettyShader { get; }
+
+    [ComputeShader(""cs/blur.slang"")]
+    private partial IComputeShader BlurShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Empty(runResult.Diagnostics);
+
+        var generatedFileSyntax = runResult.GeneratedTrees.Single(t => t.FilePath.Contains("ShaderUser"));
+        var generatedText = generatedFileSyntax.GetText().ToString();
+
+        Assert.Contains(
+            "public partial global::Rin.Core.Graphics.Shaders.IGraphicsShader PrettyShader => field ??= global::Rin.Core.Graphics.IGraphicsModule.Get().MakeGraphics(\"fs/pretty.slang\");",
+            generatedText);
+        Assert.Contains(
+            "private partial global::Rin.Core.Graphics.Shaders.IComputeShader BlurShader => field ??= global::Rin.Core.Graphics.IGraphicsModule.Get().MakeCompute(\"cs/blur.slang\");",
+            generatedText);
+    }
+
+    [Fact]
+    public void ContainingTypeMustBePartial()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public partial IGraphicsShader PrettyShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00013");
+    }
+
+    [Fact]
+    public void PropertyMustBePartial()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public IGraphicsShader PrettyShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00014");
+    }
+
+    [Fact]
+    public void PropertyMustBeGetOnly()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public partial IGraphicsShader PrettyShader { get; set; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00015");
+    }
+
+    [Fact]
+    public void PropertyTypeMustMatchAttribute()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public partial string PrettyShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00016");
+    }
+
+    [Fact]
+    public void PropertyMustNotBeStatic()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    public static partial IGraphicsShader PrettyShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00017");
+    }
+
+    [Fact]
+    public void AmbiguousShaderAttributeIsRejected()
+    {
+        const string source = @"
+using Rin.Core.Graphics.Shaders;
+
+namespace TestNamespace;
+
+public partial class ShaderUser
+{
+    [GraphicsShader(""fs/pretty.slang"")]
+    [ComputeShader(""cs/blur.slang"")]
+    public partial IGraphicsShader PrettyShader { get; }
+}
+";
+        var runResult = Run(source);
+
+        Assert.Contains(runResult.Diagnostics, d => d.Id == "RIN00012");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new `GraphicsShaderGenerator` plus `[GraphicsShader]`/`[ComputeShader]` attributes (backed by a shared `ShaderAttribute` base) so shader-holding partial properties are generated instead of hand-written eager `IGraphicsModule.Get().MakeGraphics(...)` field initializers (`BlurCommandHandler`, `StencilWritePass`, `DefaultQuadBatcher`, `VideoPlayerView`).
- Extracts `IsPartial`/`GetSafeHintName` out of `AudioEffectGenerator` into a shared `GeneratorUtils`, and adds new `RIN00012`-`RIN00017` diagnostics for the shader generator.
- Removes the unused, already-commented-out `LoadShaderAttribute.cs`.
- Threads module/service dependencies (`IGraphicsModule`, `IAudioModule`, `IApplication`, `IViewsModule`) through optional constructor parameters on `AnimationRunner`, `WebmVideoPlayer`, `TextBoxView`, `TextInputBoxView`, `Surface`, `SixLaborsFontManager`, and `HostImage.CreateTexture`, instead of only resolving them via static `Get()` calls, to make these types easier to construct in isolation.
- Adds `GraphicsShaderGeneratorTests`.

## Test plan
- [ ] `dotnet build` succeeds
- [ ] `dotnet test Rin.SourceGenerators/Rin.SourceGenerators.Tests` passes, including the new `GraphicsShaderGeneratorTests`
- [ ] Manually verify a view using `[GraphicsShader]` (e.g. `DefaultQuadBatcher`) still renders correctly